### PR TITLE
Add IrisController and IrisActivity

### DIFF
--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisActivity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Team 7, CMPUT301, University of Alberta - All Rights Reserved. You may use, distribute, or modify this code under terms and conditions of the Code of Students Behavior at University of Alberta
+ *
+ *
+ */
+
+package com.team7.cmput301.android.theirisproject;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+
+import com.team7.cmput301.android.theirisproject.controller.IrisController;
+
+/**
+ * An type of Activity that uses a IrisController to a) interact with and update with a Model object,
+ * and b) get Intent extra data in order start another IrisActivity.
+ *
+ * @author anticobalt
+ * @see IrisController
+ */
+public abstract class IrisActivity extends AppCompatActivity {
+
+    /**
+     * Initialize IrisController with the Model object
+     * @param model The Model object (e.g. Problem)
+     * @return The IrisController (e.g. ProblemController)
+     */
+    protected abstract IrisController createController(Intent intent);
+
+    /**
+     * Use IrisController to fill Intent with Model object data
+     * @param intent Intent that describes the transition from this IrisActivity to another
+     * @param controller IrisController associated with this IrisActivity
+     * @return The original passed Intent, now modified with proper extras
+     */
+    protected Intent fillExtras(Intent intent, IrisController controller){
+        return controller.bindModelToIntent(intent);
+    }
+
+}

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisActivity.java
@@ -6,10 +6,7 @@
 
 package com.team7.cmput301.android.theirisproject;
 
-import android.app.Activity;
 import android.content.Intent;
-import android.os.Parcelable;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
 import com.team7.cmput301.android.theirisproject.controller.IrisController;
@@ -24,8 +21,11 @@ import com.team7.cmput301.android.theirisproject.controller.IrisController;
 public abstract class IrisActivity extends AppCompatActivity {
 
     /**
-     * Initialize IrisController with the Model object
-     * @param model The Model object (e.g. Problem)
+     * Initialize IrisController with the Model object.
+     * Typically involves calling constructor with Intent's Parcelable extra (as the Intent holds
+     * the Model object); if this is done, the extra will have to be cast to whatever type the
+     * controller's constructor accepts (e.g. Problem).
+     * @param intent The Intent given by the IrisActivity that started this IrisActivity
      * @return The IrisController (e.g. ProblemController)
      */
     protected abstract IrisController createController(Intent intent);

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/LoginActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/LoginActivity.java
@@ -30,7 +30,7 @@ public class LoginActivity extends IrisActivity {
 
         // First activity must create fake Intent
         Intent intent = new Intent();
-        intent.putExtra("model", new Profile(null, null, null));
+        intent.putExtra("new_profile", new Profile(null, null, null));
         this.controller = createController(intent);
 
         registerButton.setOnClickListener(new View.OnClickListener() {
@@ -46,6 +46,6 @@ public class LoginActivity extends IrisActivity {
 
     @Override
     protected IrisController createController(Intent intent) {
-        return new LoginController(intent);
+        return new LoginController((Profile) intent.getParcelableExtra("new_profile"));
     }
 }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/LoginActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/LoginActivity.java
@@ -5,15 +5,20 @@
 package com.team7.cmput301.android.theirisproject;
 
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
-public class LoginActivity extends AppCompatActivity {
+import com.team7.cmput301.android.theirisproject.controller.IrisController;
+import com.team7.cmput301.android.theirisproject.controller.LoginController;
+import com.team7.cmput301.android.theirisproject.model.Profile;
+
+public class LoginActivity extends IrisActivity {
 
     private Button loginButton;
     private Button registerButton;
+
+    private IrisController controller;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,13 +28,24 @@ public class LoginActivity extends AppCompatActivity {
         loginButton = findViewById(R.id.login_button);
         registerButton = findViewById(R.id.register_button);
 
+        // First activity must create fake Intent
+        Intent intent = new Intent();
+        intent.putExtra("model", new Profile(null, null, null));
+        this.controller = createController(intent);
+
         registerButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(LoginActivity.this, RegisterActivity.class);
+                intent = fillExtras(intent, LoginActivity.this.controller);
                 startActivity(intent);
             }
         });
 
+    }
+
+    @Override
+    protected IrisController createController(Intent intent) {
+        return new LoginController(intent);
     }
 }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/RegisterActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/RegisterActivity.java
@@ -4,14 +4,29 @@
 
 package com.team7.cmput301.android.theirisproject;
 
-import android.support.v7.app.AppCompatActivity;
+import android.content.Intent;
 import android.os.Bundle;
 
-public class RegisterActivity extends AppCompatActivity {
+import com.team7.cmput301.android.theirisproject.controller.IrisController;
+
+public class RegisterActivity extends IrisActivity {
+
+    IrisController controller;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register);
+        this.controller = createController(getIntent());
+    }
+
+    @Override
+    protected IrisController createController(Intent intent) {
+        return null;
+    }
+
+    @Override
+    protected Intent fillExtras(Intent intent, IrisController controller) {
+        return null;
     }
 }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/IrisController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/IrisController.java
@@ -23,10 +23,20 @@ public abstract class IrisController {
 
     protected Parcelable model;
 
+    /**
+     * The constructor of an IrisController subclass can take in a specific Model class
+     * (e.g. Problem) and use it make a class to super(), as long as that Model implements Parcelable.
+     * @param model Any Parcelable object
+     */
     IrisController(Parcelable model){
         this.model = model;
     }
 
+    /**
+     * Put the associated model object into the passed Intent, and return it.
+     * @param intent Calling Activity's Intent
+     * @return Modified Intent
+     */
     public Intent bindModelToIntent(Intent intent){
         intent.putExtra("model", model);
         return intent;

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/IrisController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/IrisController.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Team 7, CMPUT301, University of Alberta - All Rights Reserved. You may use, distribute, or modify this code under terms and conditions of the Code of Students Behavior at University of Alberta
+ *
+ *
+ */
+
+package com.team7.cmput301.android.theirisproject.controller;
+
+import android.content.Intent;
+import android.os.Parcelable;
+
+import com.team7.cmput301.android.theirisproject.IrisActivity;
+
+/**
+ * A type of controller that is used by an IrisActivity to manage a Model object. The IrisController
+ * is responsible for updating the Model object, interpreting the Model object, and binding it to
+ * an Intent so that the IrisActivity can start another IrisActivity.
+ *
+ * @author anticobalt
+ * @see IrisActivity
+ */
+public abstract class IrisController {
+
+    protected Parcelable model;
+
+    IrisController(Parcelable model){
+        this.model = model;
+    }
+
+    public Intent bindModelToIntent(Intent intent){
+        intent.putExtra("model", model);
+        return intent;
+    }
+
+}

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/LoginController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/LoginController.java
@@ -6,12 +6,18 @@
 
 package com.team7.cmput301.android.theirisproject.controller;
 
-import android.os.Parcelable;
+import com.team7.cmput301.android.theirisproject.model.Profile;
 
+
+/**
+ * Controller for handling user actions and interacting with Profile in LoginActivity
+ *
+ * @author anticobalt
+ */
 public class LoginController extends IrisController {
 
-    public LoginController(Parcelable model){
-        super(model);
+    public LoginController(Profile profile){
+        super(profile);
     }
 
 }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/LoginController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/LoginController.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Team 7, CMPUT301, University of Alberta - All Rights Reserved. You may use, distribute, or modify this code under terms and conditions of the Code of Students Behavior at University of Alberta
+ *
+ *
+ */
+
+package com.team7.cmput301.android.theirisproject.controller;
+
+import android.os.Parcelable;
+
+public class LoginController extends IrisController {
+
+    public LoginController(Parcelable model){
+        super(model);
+    }
+
+}

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/model/Profile.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/model/Profile.java
@@ -4,7 +4,10 @@
 
 package com.team7.cmput301.android.theirisproject.model;
 
-public class Profile {
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Profile implements Parcelable {
     private String username;
     private String email;
     private String phoneNumber;
@@ -34,4 +37,34 @@ public class Profile {
     public Profile getProfile() {
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.username);
+        dest.writeString(this.email);
+        dest.writeString(this.phoneNumber);
+    }
+
+    protected Profile(Parcel in) {
+        this.username = in.readString();
+        this.email = in.readString();
+        this.phoneNumber = in.readString();
+    }
+
+    public static final Parcelable.Creator<Profile> CREATOR = new Parcelable.Creator<Profile>() {
+        @Override
+        public Profile createFromParcel(Parcel source) {
+            return new Profile(source);
+        }
+
+        @Override
+        public Profile[] newArray(int size) {
+            return new Profile[size];
+        }
+    };
 }


### PR DESCRIPTION
Provides a) custom abstract activity and controller to enforce MVC, and b) example implementation of these classes in the login and profile activities.

Implications of using these classes:
- Activities have controllers and views, but not models
- Controllers have models
- All activities and their controllers should extend these two abstract classes
- If an Activity needs to start another Activity in response to user events (ideally with  startActivityForResult(), so that changes to model can be detected), it must ask its controller to attach its model object to an Intent; this Intent is used to start activity as normal
- When an Activity is started, it creates whatever controller it needs using its own createController() method, which uses the received Intent
- Controllers are constructed using relevant models
- Models must implement Parcelable in order to be attached to Intents. Alternatively, they could implement Serializable, but this is apparently slow. Implementing Parcelable is significantly more work to do (by hand) than implementing Serializable, so [this plugin](https://github.com/mcharmas/android-parcelable-intellij-plugin) can be used to avoid most of the work