### PR TITLE
Fix crash upon back button in AddProblemActivity

### DIFF
--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/ProblemListController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/ProblemListController.java
@@ -9,6 +9,7 @@ package com.team7.cmput301.android.theirisproject.controller;
 import android.content.Intent;
 import android.os.Bundle;
 
+import com.team7.cmput301.android.theirisproject.IrisProjectApplication;
 import com.team7.cmput301.android.theirisproject.task.Callback;
 import com.team7.cmput301.android.theirisproject.task.GetProblemListTask;
 import com.team7.cmput301.android.theirisproject.model.ProblemList;
@@ -27,7 +28,7 @@ public class ProblemListController extends IrisController<ProblemList> {
     public ProblemListController(Intent intent) {
         super(intent);
         this.model = getModel(intent.getExtras());
-        this.userID = intent.getExtras().getString("user");
+        this.userID = IrisProjectApplication.getCurrentUser().getId();
     }
 
     /**


### PR DESCRIPTION
This fixes issue #69, which was cause by the line `this.userID = intent.getExtras().getString("user");` in ProblemListController. When leaving from AddProblemActivity, the intent for ProblemListActivity no longer had an that extra in its intent.