### PR TITLE
Add RegisterActivity tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,17 +21,19 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.android.support:design:27.1.1'
     implementation 'io.searchbox:jest-droid:5.3.4'
-
     implementation 'com.google.android.gms:play-services-maps:16.0.0'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    implementation 'com.jayway.android.robotium:robotium-solo:5.6.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    implementation 'com.jayway.android.robotium:robotium-solo:5.6.3'
+    androidTestImplementation 'com.jayway.android.robotium:robotium-solo:5.6.3'
 }

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 /**
- * RegisterActivityTest2 contains tests pertaining to registering users in RegisterActivity
+ * RegisterActivityTest contains tests pertaining to registering users in RegisterActivity
  *
  * @author Jmmxp
  * @see RegisterActivity
@@ -47,7 +47,10 @@ public class RegisterActivityTest {
         }
     }
 
-    // Test registration when not all fields have been filled out
+
+    /**
+     * Test registration when not all fields have been filled out
+     */
     @Test
     public void testRegisterIncomplete() {
         onView(withId(R.id.register_button))
@@ -65,10 +68,9 @@ public class RegisterActivityTest {
         checkToast(getString(R.string.register_incomplete));
     }
 
-    // Currently only works if the account has already been registered
-
     /**
      * Test registration when all fields are filled out but the email is already in use
+     * Currently only works if the account has already been registered
      */
     @Test
     public void testRegisterAlreadyRegistered() {
@@ -86,6 +88,7 @@ public class RegisterActivityTest {
 
     /**
      * Test registration when all fields are filled out and user is registered successfully
+     * Currently only works if the account is guaranteed not to be registered
      */
     @Test
     public void testRegisterSuccess() {
@@ -107,6 +110,10 @@ public class RegisterActivityTest {
                 .perform(typeText(text));
     }
 
+    /**
+     * Closes they keyboard and sleeps for 0.25s, this is currently needed or else the test tries to
+     * click the button before the keyboard is closed which causes it to fail
+     */
     private void closeKeyboardAndWait() {
         Espresso.closeSoftKeyboard();
         try {

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -60,7 +60,7 @@ public class RegisterActivityTest extends ActivityInstrumentationTestCase2<Regis
 //        assertTrue(solo.waitForText(getString(R.string.register_success)));
 //    }
 //
-//    // Test registration when all fields have been filled out
+    // Test registration when all fields have been filled out
 //    public void testRegisterComplete() {
 //        Button registerButton = (Button) solo.getView(R.id.register_button);
 //
@@ -78,7 +78,7 @@ public class RegisterActivityTest extends ActivityInstrumentationTestCase2<Regis
 //
 //        solo.clickOnView(registerButton);
 //
-//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
+//        assertTrue(solo.waitForText(getString(R.string.register_failure)) || solo.waitForText(getString(R.string.register_incomplete)));
 //    }
 //
 //    private String getString(int stringId) {

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -40,6 +40,11 @@ public class RegisterActivityTest {
     @Before
     public void setUp() {
         activity = activityRule.getActivity();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     // Test registration when not all fields have been filled out

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -1,88 +1,126 @@
 package com.team7.cmput301.android.theirisproject;
 
-import android.test.ActivityInstrumentationTestCase2;
-import android.widget.Button;
-import android.widget.EditText;
+import android.app.Activity;
+import android.support.test.espresso.Espresso;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
 
-import com.robotium.solo.Solo;
-import com.team7.cmput301.android.theirisproject.R;
 import com.team7.cmput301.android.theirisproject.activity.RegisterActivity;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.*;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 /**
- * Contains register tests for RegisterActivity
- *
+ * RegisterActivityTest2 contains tests pertaining to registering users in RegisterActivity
  *
  * @author Jmmxp
  * @see RegisterActivity
  */
-public class RegisterActivityTest extends ActivityInstrumentationTestCase2<RegisterActivity> {
 
-    // TODO: The tests in here do not work due to Solo ClassNotFound exceptions and the like
-    // We have to decide if we want to use Robotium or Espresso
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class RegisterActivityTest {
 
-    private Solo solo;
+    private Activity activity;
 
-    public RegisterActivityTest() {
-        super(RegisterActivity.class);
+    @Rule
+    public ActivityTestRule<RegisterActivity> activityRule = new ActivityTestRule<>(RegisterActivity.class);
+
+    @Before
+    public void setUp() {
+        activity = activityRule.getActivity();
     }
 
-//    @Override
-//    protected void setUp() throws Exception {
-//        super.setUp();
-//        solo = new Solo(getInstrumentation(), getActivity());
-//    }
-//
-//    @Override
-//    protected void tearDown() throws Exception {
-//        super.tearDown();
-//        solo.finishOpenedActivities();
-//    }
-//
-//    public void testActivity() {
-//        String activityName = RegisterActivity.class.getSimpleName();
-//        solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
-//    }
-//
-//    // Test registration when not all fields have been filled out
-//    public void testRegisterIncomplete() {
-//        Button registerButton = (Button) solo.getView(R.id.register_button);
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
-//
-//        // Try registering with only the name field filled out
-//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
-//        solo.enterText(nameEditText, "John Doe");
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_success)));
-//    }
-//
-    // Test registration when all fields have been filled out
-//    public void testRegisterComplete() {
-//        Button registerButton = (Button) solo.getView(R.id.register_button);
-//
-//
-//        // Try registering with only the name field filled out
-//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
-//        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
-//        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
-//        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
-//
-//        solo.enterText(nameEditText, "John Doe");
-//        solo.enterText(passwordEditText, "badpassword");
-//        solo.enterText(emailEditText, "johndoe@gmail.com");
-//        solo.enterText(phoneEditText, "123-456-7890");
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_failure)) || solo.waitForText(getString(R.string.register_incomplete)));
-//    }
-//
-//    private String getString(int stringId) {
-//        return getActivity().getString(stringId);
-//    }
+    // Test registration when not all fields have been filled out
+    @Test
+    public void testRegisterIncomplete() {
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_incomplete));
+
+        fillEditText(R.id.name_edit_text, "John Doe");
+
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_incomplete));
+    }
+
+    // Currently only works if the account has already been registered
+
+    /**
+     * Test registration when all fields are filled out but the email is already in use
+     */
+    @Test
+    public void testRegisterAlreadyRegistered() {
+        fillEditText(R.id.name_edit_text, "John Doe");
+        fillEditText(R.id.password_edit_text, "badpassword");
+        fillEditText(R.id.email_edit_text, "johndoe@gmail.com");
+        fillEditText(R.id.phone_edit_text, "123-456-7890");
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_failure));
+    }
+
+    /**
+     * Test registration when all fields are filled out and user is registered successfully
+     */
+    @Test
+    public void testRegisterSuccess() {
+        fillEditText(R.id.name_edit_text, "John Doe");
+        fillEditText(R.id.password_edit_text, "badpassword");
+        fillEditText(R.id.email_edit_text, "johndoe2@gmail.com");
+        fillEditText(R.id.phone_edit_text, "123-456-7890");
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        // TODO: Delete test user from the DB, or use a mock DB before doing this test
+        // checkToast(getString(R.string.register_success));
+    }
+
+    private void fillEditText(int editTextResId, String text) {
+        onView(withId(editTextResId))
+                .perform(typeText(text));
+    }
+
+    private void closeKeyboardAndWait() {
+        Espresso.closeSoftKeyboard();
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Check if a Toast displays given text
+    // REFERENCE: https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso
+    private void checkToast(String toastText) {
+        onView(withText(toastText))
+                .inRoot(withDecorView(not(is(activity.getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+    }
+
+    private String getString(int stringResId) {
+        return activity.getString(stringResId);
+    }
 
 }

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -123,8 +123,10 @@ public class RegisterActivityTest {
         }
     }
 
-    // Check if a Toast displays given text
-    // REFERENCE: https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso
+    /**
+     * Check if a Toast displays given text
+     * REFERENCE: https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso
+     */
     private void checkToast(String toastText) {
         onView(withText(toastText))
                 .inRoot(withDecorView(not(is(activity.getWindow().getDecorView()))))

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest.java
@@ -1,0 +1,88 @@
+package com.team7.cmput301.android.theirisproject;
+
+import android.test.ActivityInstrumentationTestCase2;
+import android.widget.Button;
+import android.widget.EditText;
+
+import com.robotium.solo.Solo;
+import com.team7.cmput301.android.theirisproject.R;
+import com.team7.cmput301.android.theirisproject.activity.RegisterActivity;
+
+/**
+ * Contains register tests for RegisterActivity
+ *
+ *
+ * @author Jmmxp
+ * @see RegisterActivity
+ */
+public class RegisterActivityTest extends ActivityInstrumentationTestCase2<RegisterActivity> {
+
+    // TODO: The tests in here do not work due to Solo ClassNotFound exceptions and the like
+    // We have to decide if we want to use Robotium or Espresso
+
+    private Solo solo;
+
+    public RegisterActivityTest() {
+        super(RegisterActivity.class);
+    }
+
+//    @Override
+//    protected void setUp() throws Exception {
+//        super.setUp();
+//        solo = new Solo(getInstrumentation(), getActivity());
+//    }
+//
+//    @Override
+//    protected void tearDown() throws Exception {
+//        super.tearDown();
+//        solo.finishOpenedActivities();
+//    }
+//
+//    public void testActivity() {
+//        String activityName = RegisterActivity.class.getSimpleName();
+//        solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
+//    }
+//
+//    // Test registration when not all fields have been filled out
+//    public void testRegisterIncomplete() {
+//        Button registerButton = (Button) solo.getView(R.id.register_button);
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
+//
+//        // Try registering with only the name field filled out
+//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+//        solo.enterText(nameEditText, "John Doe");
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_success)));
+//    }
+//
+//    // Test registration when all fields have been filled out
+//    public void testRegisterComplete() {
+//        Button registerButton = (Button) solo.getView(R.id.register_button);
+//
+//
+//        // Try registering with only the name field filled out
+//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+//        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
+//        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
+//        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
+//
+//        solo.enterText(nameEditText, "John Doe");
+//        solo.enterText(passwordEditText, "badpassword");
+//        solo.enterText(emailEditText, "johndoe@gmail.com");
+//        solo.enterText(phoneEditText, "123-456-7890");
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
+//    }
+//
+//    private String getString(int stringId) {
+//        return getActivity().getString(stringId);
+//    }
+
+}

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
@@ -26,63 +26,79 @@ public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<Regi
         super(RegisterActivity.class);
     }
 
-//    @Override
-//    protected void setUp() throws Exception {
-//        super.setUp();
-//        solo = new Solo(getInstrumentation(), getActivity());
-//    }
-//
-//    @Override
-//    protected void tearDown() throws Exception {
-//        super.tearDown();
-//        solo.finishOpenedActivities();
-//    }
-//
-//    public void testActivity() {
-//        String activityName = RegisterActivity.class.getSimpleName();
-//        solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
-//    }
-//
-//    // Test registration when not all fields have been filled out
-//    public void testRegisterIncomplete() {
-//        Button registerButton = (Button) solo.getView(R.id.register_button);
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
-//
-//        // Try registering with only the name field filled out
-//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
-//        solo.enterText(nameEditText, "John Doe");
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_success)));
-//    }
-//
+    @Override
+    protected void setUp() {
+        solo = new Solo(getInstrumentation(), getActivity());
+    }
+
+    @Override
+    protected void tearDown() {
+        solo.finishOpenedActivities();
+    }
+
+    public void testActivity() {
+        String activityName = RegisterActivity.class.getSimpleName();
+        solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
+    }
+
+    // Test registration when not all fields have been filled out
+    public void testRegisterIncomplete() {
+        Button registerButton = (Button) solo.getView(R.id.register_button);
+
+        solo.clickOnView(registerButton);
+
+        assertTrue(solo.waitForText(getString(R.string.register_incomplete)));
+
+        // Try registering with only the name field filled out
+        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+        solo.enterText(nameEditText, "John Doe");
+
+        solo.clickOnView(registerButton);
+
+        assertTrue(solo.waitForText(getString(R.string.register_incomplete)));
+    }
+
+    public void testRegisterAlreadyRegistered() {
+        Button registerButton = (Button) solo.getView(R.id.register_button);
+
+        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
+        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
+        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
+
+        solo.enterText(nameEditText, "John Doe");
+        solo.enterText(passwordEditText, "badpassword");
+        solo.enterText(emailEditText, "johndoe@gmail.com");
+        solo.enterText(phoneEditText, "123-456-7890");
+
+        solo.clickOnView(registerButton);
+
+        // TODO: Add user to DB before doing this test
+        assertTrue(solo.waitForText(getString(R.string.register_failure)));
+    }
+
     // Test registration when all fields have been filled out
-//    public void testRegisterComplete() {
-//        Button registerButton = (Button) solo.getView(R.id.register_button);
-//
-//
-//        // Try registering with only the name field filled out
-//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
-//        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
-//        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
-//        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
-//
-//        solo.enterText(nameEditText, "John Doe");
-//        solo.enterText(passwordEditText, "badpassword");
-//        solo.enterText(emailEditText, "johndoe@gmail.com");
-//        solo.enterText(phoneEditText, "123-456-7890");
-//
-//        solo.clickOnView(registerButton);
-//
-//        assertTrue(solo.waitForText(getString(R.string.register_failure)) || solo.waitForText(getString(R.string.register_incomplete)));
-//    }
-//
-//    private String getString(int stringId) {
-//        return getActivity().getString(stringId);
-//    }
+    public void testRegisterSuccess() {
+        Button registerButton = (Button) solo.getView(R.id.register_button);
+
+        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
+        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
+        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
+
+        solo.enterText(nameEditText, "John Doe");
+        solo.enterText(passwordEditText, "badpassword");
+        solo.enterText(emailEditText, "johndoe@gmail.com");
+        solo.enterText(phoneEditText, "123-456-7890");
+
+        solo.clickOnView(registerButton);
+
+        // TODO: Delete user from DB if exists before doing this test
+        // assertTrue(solo.waitForText(getString(R.string.register_success)));
+    }
+
+    private String getString(int stringId) {
+        return getActivity().getString(stringId);
+    }
 
 }

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
@@ -17,7 +17,6 @@ import com.team7.cmput301.android.theirisproject.activity.RegisterActivity;
  */
 public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<RegisterActivity> {
 
-    // TODO: The tests in here do not work due to Solo ClassNotFound exceptions and the like
     // We have to decide if we want to use Robotium or Espresso
 
     private Solo solo;

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
@@ -1,0 +1,126 @@
+package com.team7.cmput301.android.theirisproject;
+
+import android.app.Activity;
+import android.support.test.espresso.Espresso;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.team7.cmput301.android.theirisproject.activity.RegisterActivity;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.*;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * RegisterActivityTest contains tests pertaining to registering users in RegisterActivity
+ *
+ * @author Jmmxp
+ * @see RegisterActivity
+ */
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class RegisterActivityTest2 {
+
+    private Activity activity;
+
+    @Rule
+    public ActivityTestRule<RegisterActivity> activityRule = new ActivityTestRule<>(RegisterActivity.class);
+
+    @Before
+    public void setUp() {
+        activity = activityRule.getActivity();
+    }
+
+    // Test registration when not all fields have been filled out
+    @Test
+    public void testRegisterIncomplete() {
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_incomplete));
+
+        fillEditText(R.id.name_edit_text, "John Doe");
+
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_incomplete));
+    }
+
+    // Currently only works if the account has already been registered
+
+    /**
+     * Test registration when all fields are filled out but the email is already in use
+     */
+    @Test
+    public void testRegisterAlreadyRegistered() {
+        fillEditText(R.id.name_edit_text, "John Doe");
+        fillEditText(R.id.password_edit_text, "badpassword");
+        fillEditText(R.id.email_edit_text, "johndoe@gmail.com");
+        fillEditText(R.id.phone_edit_text, "123-456-7890");
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        checkToast(getString(R.string.register_failure));
+    }
+
+    /**
+     * Test registration when all fields are filled out and user is registered successfully
+     */
+    @Test
+    public void testRegisterSuccess() {
+        fillEditText(R.id.name_edit_text, "John Doe");
+        fillEditText(R.id.password_edit_text, "badpassword");
+        fillEditText(R.id.email_edit_text, "johndoe2@gmail.com");
+        fillEditText(R.id.phone_edit_text, "123-456-7890");
+
+        closeKeyboardAndWait();
+        onView(withId(R.id.register_button))
+                .perform(click());
+
+        // TODO: Delete test user from the DB, or use a mock DB before doing this test
+        // checkToast(getString(R.string.register_success));
+    }
+
+    private void fillEditText(int editTextResId, String text) {
+        onView(withId(editTextResId))
+                .perform(typeText(text));
+    }
+
+    private void closeKeyboardAndWait() {
+        Espresso.closeSoftKeyboard();
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Check if a Toast displays given text
+    // REFERENCE: https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso
+    private void checkToast(String toastText) {
+        onView(withText(toastText))
+                .inRoot(withDecorView(not(is(activity.getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+    }
+
+    private String getString(int stringResId) {
+        return activity.getString(stringResId);
+    }
+
+}

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
@@ -40,7 +40,9 @@ public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<Regi
         solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
     }
 
-    // Test registration when not all fields have been filled out
+    /**
+     * Test registration when not all fields have been filled out
+     */
     public void testRegisterIncomplete() {
         Button registerButton = (Button) solo.getView(R.id.register_button);
 
@@ -57,6 +59,10 @@ public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<Regi
         assertTrue(solo.waitForText(getString(R.string.register_incomplete)));
     }
 
+    /**
+     * Test registration when all fields are filled out but the email is already in use
+     * Currently only works if the account has already been registered
+     */
     public void testRegisterAlreadyRegistered() {
         Button registerButton = (Button) solo.getView(R.id.register_button);
 
@@ -76,7 +82,10 @@ public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<Regi
         assertTrue(solo.waitForText(getString(R.string.register_failure)));
     }
 
-    // Test registration when all fields have been filled out
+    /**
+     * Test registration when all fields are filled out and user is registered successfully
+     * Currently only works if the account is guaranteed not to be registered
+     */
     public void testRegisterSuccess() {
         Button registerButton = (Button) solo.getView(R.id.register_button);
 

--- a/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
+++ b/app/src/androidTest/java/com/team7/cmput301/android/theirisproject/RegisterActivityTest2.java
@@ -1,126 +1,88 @@
 package com.team7.cmput301.android.theirisproject;
 
-import android.app.Activity;
-import android.support.test.espresso.Espresso;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import android.test.ActivityInstrumentationTestCase2;
+import android.widget.Button;
+import android.widget.EditText;
 
+import com.robotium.solo.Solo;
+import com.team7.cmput301.android.theirisproject.R;
 import com.team7.cmput301.android.theirisproject.activity.RegisterActivity;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.*;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.RootMatchers.*;
-import static android.support.test.espresso.matcher.ViewMatchers.*;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-
 /**
- * RegisterActivityTest contains tests pertaining to registering users in RegisterActivity
+ * Contains register tests for RegisterActivity
+ *
  *
  * @author Jmmxp
  * @see RegisterActivity
  */
+public class RegisterActivityTest2 extends ActivityInstrumentationTestCase2<RegisterActivity> {
 
-@RunWith(AndroidJUnit4.class)
-@LargeTest
-public class RegisterActivityTest2 {
+    // TODO: The tests in here do not work due to Solo ClassNotFound exceptions and the like
+    // We have to decide if we want to use Robotium or Espresso
 
-    private Activity activity;
+    private Solo solo;
 
-    @Rule
-    public ActivityTestRule<RegisterActivity> activityRule = new ActivityTestRule<>(RegisterActivity.class);
-
-    @Before
-    public void setUp() {
-        activity = activityRule.getActivity();
+    public RegisterActivityTest2() {
+        super(RegisterActivity.class);
     }
 
-    // Test registration when not all fields have been filled out
-    @Test
-    public void testRegisterIncomplete() {
-        onView(withId(R.id.register_button))
-                .perform(click());
-
-        checkToast(getString(R.string.register_incomplete));
-
-        fillEditText(R.id.name_edit_text, "John Doe");
-
-
-        closeKeyboardAndWait();
-        onView(withId(R.id.register_button))
-                .perform(click());
-
-        checkToast(getString(R.string.register_incomplete));
-    }
-
-    // Currently only works if the account has already been registered
-
-    /**
-     * Test registration when all fields are filled out but the email is already in use
-     */
-    @Test
-    public void testRegisterAlreadyRegistered() {
-        fillEditText(R.id.name_edit_text, "John Doe");
-        fillEditText(R.id.password_edit_text, "badpassword");
-        fillEditText(R.id.email_edit_text, "johndoe@gmail.com");
-        fillEditText(R.id.phone_edit_text, "123-456-7890");
-
-        closeKeyboardAndWait();
-        onView(withId(R.id.register_button))
-                .perform(click());
-
-        checkToast(getString(R.string.register_failure));
-    }
-
-    /**
-     * Test registration when all fields are filled out and user is registered successfully
-     */
-    @Test
-    public void testRegisterSuccess() {
-        fillEditText(R.id.name_edit_text, "John Doe");
-        fillEditText(R.id.password_edit_text, "badpassword");
-        fillEditText(R.id.email_edit_text, "johndoe2@gmail.com");
-        fillEditText(R.id.phone_edit_text, "123-456-7890");
-
-        closeKeyboardAndWait();
-        onView(withId(R.id.register_button))
-                .perform(click());
-
-        // TODO: Delete test user from the DB, or use a mock DB before doing this test
-        // checkToast(getString(R.string.register_success));
-    }
-
-    private void fillEditText(int editTextResId, String text) {
-        onView(withId(editTextResId))
-                .perform(typeText(text));
-    }
-
-    private void closeKeyboardAndWait() {
-        Espresso.closeSoftKeyboard();
-        try {
-            Thread.sleep(250);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
-    // Check if a Toast displays given text
-    // REFERENCE: https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso
-    private void checkToast(String toastText) {
-        onView(withText(toastText))
-                .inRoot(withDecorView(not(is(activity.getWindow().getDecorView()))))
-                .check(matches(isDisplayed()));
-    }
-
-    private String getString(int stringResId) {
-        return activity.getString(stringResId);
-    }
+//    @Override
+//    protected void setUp() throws Exception {
+//        super.setUp();
+//        solo = new Solo(getInstrumentation(), getActivity());
+//    }
+//
+//    @Override
+//    protected void tearDown() throws Exception {
+//        super.tearDown();
+//        solo.finishOpenedActivities();
+//    }
+//
+//    public void testActivity() {
+//        String activityName = RegisterActivity.class.getSimpleName();
+//        solo.assertCurrentActivity("Wrong activity found, should be " + activityName, activityName);
+//    }
+//
+//    // Test registration when not all fields have been filled out
+//    public void testRegisterIncomplete() {
+//        Button registerButton = (Button) solo.getView(R.id.register_button);
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_failure)));
+//
+//        // Try registering with only the name field filled out
+//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+//        solo.enterText(nameEditText, "John Doe");
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_success)));
+//    }
+//
+    // Test registration when all fields have been filled out
+//    public void testRegisterComplete() {
+//        Button registerButton = (Button) solo.getView(R.id.register_button);
+//
+//
+//        // Try registering with only the name field filled out
+//        EditText nameEditText = (EditText) solo.getView(R.id.name_edit_text);
+//        EditText passwordEditText = (EditText) solo.getView(R.id.password_edit_text);
+//        EditText emailEditText = (EditText) solo.getView(R.id.email_edit_text);
+//        EditText phoneEditText = (EditText) solo.getView(R.id.phone_edit_text);
+//
+//        solo.enterText(nameEditText, "John Doe");
+//        solo.enterText(passwordEditText, "badpassword");
+//        solo.enterText(emailEditText, "johndoe@gmail.com");
+//        solo.enterText(phoneEditText, "123-456-7890");
+//
+//        solo.clickOnView(registerButton);
+//
+//        assertTrue(solo.waitForText(getString(R.string.register_failure)) || solo.waitForText(getString(R.string.register_incomplete)));
+//    }
+//
+//    private String getString(int stringId) {
+//        return getActivity().getString(stringId);
+//    }
 
 }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/RegisterActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/RegisterActivity.java
@@ -47,7 +47,7 @@ public class RegisterActivity extends IrisActivity {
         setContentView(R.layout.activity_register);
         controller = (RegisterController) createController(getIntent());
 
-        usernameEditText = findViewById(R.id.username_edit_text);
+        usernameEditText = findViewById(R.id.name_edit_text);
         passwordEditText = findViewById(R.id.password_edit_text);
         emailEditText = findViewById(R.id.email_edit_text);
         phoneEditText = findViewById(R.id.phone_edit_text);
@@ -75,7 +75,7 @@ public class RegisterActivity extends IrisActivity {
         String[] fields = {username, password, email, phoneNumber};
 
         if (StringHelper.hasEmptyString(Arrays.asList(fields))) {
-            Toast.makeText(this, "Please fill in all fields!", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, getString(R.string.register_incomplete), Toast.LENGTH_SHORT).show();
             return;
         }
 
@@ -97,10 +97,10 @@ public class RegisterActivity extends IrisActivity {
             @Override
             public void onComplete(Boolean registerSuccess) {
                 if (registerSuccess) {
-                    Toast.makeText(RegisterActivity.this, "User successfully registered!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(RegisterActivity.this, R.string.register_success, Toast.LENGTH_SHORT).show();
                     finish();
                 } else {
-                    Toast.makeText(RegisterActivity.this, "Could not register, e-mail already in use!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(RegisterActivity.this, R.string.register_failure, Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -8,7 +8,7 @@
     tools:layout_editor_absoluteY="81dp">
 
     <EditText
-        android:id="@+id/username_edit_text"
+        android:id="@+id/name_edit_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -20,7 +20,7 @@
         android:textSize="16sp"
         app:layout_constraintBottom_toTopOf="@+id/password_edit_text"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/username_text_view"
+        app:layout_constraintStart_toEndOf="@+id/name_text_view"
         app:layout_constraintTop_toBottomOf="@+id/textView" />
 
     <EditText
@@ -35,7 +35,7 @@
         android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/password_text_view"
-        app:layout_constraintTop_toBottomOf="@+id/username_edit_text" />
+        app:layout_constraintTop_toBottomOf="@+id/name_edit_text" />
 
     <EditText
         android:id="@+id/email_edit_text"
@@ -66,15 +66,15 @@
         app:layout_constraintTop_toBottomOf="@+id/email_edit_text" />
 
     <TextView
-        android:id="@+id/username_text_view"
+        android:id="@+id/name_text_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="24dp"
         android:text="@string/username_title"
         android:textSize="16sp"
-        app:layout_constraintBaseline_toBaselineOf="@+id/username_edit_text"
-        app:layout_constraintEnd_toStartOf="@+id/username_edit_text"
+        app:layout_constraintBaseline_toBaselineOf="@+id/name_edit_text"
+        app:layout_constraintEnd_toStartOf="@+id/name_edit_text"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,14 +20,14 @@
     <string name="password_title">Password</string>
     <string name="phone_title">Phone Number</string>
     <string name="email_title">Email Address</string>
-    <string name="username_hint">Enter a username</string>
-    <string name="password_hint">Enter a password</string>
-    <string name="phone_hint">Enter phone number</string>
-    <string name="email_hint">Enter email address</string>
     <string name="register_username_hint">Enter a name</string>
     <string name="register_password_hint">Enter a password</string>
     <string name="register_phone_hint">Enter phone number</string>
     <string name="register_email_hint">Enter email address</string>
+
+    <string name="register_success">User successfully registered!</string>
+    <string name="register_incomplete">Please fill in all fields!</string>
+    <string name="register_failure">Could not register, e-mail already in use!</string>
 
     <!-- Create Problem screen strings-->
     <string name="create_a_problem">Create a Problem</string>


### PR DESCRIPTION
I've set up UI testing for RegisterActivity using Espresso. I've also included the file for my original Robotium test but couldn't get the library working. If someone can get the Robotium library working then we could consider using that instead of Espresso.

This test under is performed by the test automatically typing into the fields and attempting to press the Register button, then checking the Toast text to make sure it's correct
![image](https://user-images.githubusercontent.com/11599574/48685254-98f82b00-eb72-11e8-801e-0c1c3384b54d.png)

