### PR TITLE
Multiple bug fixes (one very important one), sanity checks for AddPatientTask and increase speed of PatientList

### DIFF
--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/PatientListActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/PatientListActivity.java
@@ -86,17 +86,6 @@ public class PatientListActivity extends IrisActivity<List<Patient>> implements 
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-//        controller.getPatientsFromDB(new Callback<List<Patient>>() {
-//            @Override
-//            public void onComplete(List<Patient> res) {
-//                render(res);
-//            }
-//        });
-    }
-
-    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_patient_list, menu);
         return super.onCreateOptionsMenu(menu);
@@ -125,14 +114,8 @@ public class PatientListActivity extends IrisActivity<List<Patient>> implements 
 
     @Override
     public void onFinishAddPatient(boolean success) {
-        System.out.println("Finished adding patient!!!");
         if (success) {
-            controller.getPatientsFromDB(new Callback<List<Patient>>() {
-                @Override
-                public void onComplete(List<Patient> res) {
-                    render();
-                }
-            });
+            render();
         } else {
             // do nothing, show unsuccess Toast
             Toast.makeText(this, "Couldn't successfully add Patient!", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/helper/StringHelper.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/helper/StringHelper.java
@@ -40,6 +40,21 @@ public class StringHelper {
         return builder.toString();
     }
 
+    public static void addQuotations(List<String> strings) {
+        if (strings == null || strings.size() == 0) {
+            return;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < strings.size(); i++) {
+            String string = strings.get(i);
+            builder.append("\"" + string + "\"");
+
+            strings.set(i, builder.toString());
+            builder.setLength(0);
+        }
+    }
+
     /**
      * Given a List of Strings, determine if it has an empty or null string
      * @param strings

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/AddPatientTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/AddPatientTask.java
@@ -16,6 +16,8 @@ import com.team7.cmput301.android.theirisproject.model.CareProvider;
 import com.team7.cmput301.android.theirisproject.model.Patient;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Search;
@@ -75,6 +77,8 @@ public class AddPatientTask extends AsyncTask<String, Void, Boolean> {
 
             Patient patient = searchResult.getSourceAsObject(Patient.class, true);
 
+            careProvider.addPatient(patient);
+
             String patientId = patient.getId();
             String careProviderId = careProvider.getId();
 
@@ -82,10 +86,16 @@ public class AddPatientTask extends AsyncTask<String, Void, Boolean> {
             // Referred to Jest documentation https://github.com/searchbox-io/Jest/tree/master/jest
 
             // Append the current Patient ID onto the Care Provider's existing Patient IDs
-            String patientIds = patient.getId();
-            String patientIdsConcat = StringHelper.join(careProvider.getPatientIds(), ", ");
+            String patientIds;
+
+            List<String> patientIdList = new ArrayList<>(careProvider.getPatientIds());
+            StringHelper.addQuotations(patientIdList);
+
+            String patientIdsConcat = StringHelper.join(patientIdList, ", ");
             if (!patientIdsConcat.equals("")) {
-                patientIds = patientIdsConcat + ", " + patientId;
+                patientIds = patientIdsConcat + ", " + "\"" + patientId + "\"";
+            } else {
+                patientIds = "\"" + patientId + "\"";
             }
 
             boolean success = updateUser(client, "patientIds", patientIds, careProviderId);
@@ -98,10 +108,16 @@ public class AddPatientTask extends AsyncTask<String, Void, Boolean> {
             // Add the careProvider's ID into the Patient we're currently adding
 
             // Append the current Care Provider ID onto the Patient's existing Care Provider IDs
-            String careProviderIds = careProviderId;
-            String careProviderIdsConcat = StringHelper.join(patient.getCareProviderIds(), ", ");
+            List<String> careProviderIdList = new ArrayList<>(patient.getCareProviderIds());
+            StringHelper.addQuotations(careProviderIdList);
+
+            String careProviderIds;
+
+            String careProviderIdsConcat = StringHelper.join(careProviderIdList, ", ");
             if (!careProviderIdsConcat.equals("")) {
-                careProviderIds = careProviderIdsConcat + ", " + careProviderId;
+                careProviderIds = careProviderIdsConcat + ", " + "\"" + careProviderId + "\"";
+            } else {
+                careProviderIds = "\"" + careProviderId + "\"";
             }
 
             success = updateUser(client, "careProviderIds", careProviderIds, patientId);
@@ -131,9 +147,10 @@ public class AddPatientTask extends AsyncTask<String, Void, Boolean> {
      * @return
      */
     private boolean updateUser(JestDroidClient client, String updateType, String updateIds, String userId) {
+        System.out.println("updateIds is " + updateIds);
         String updateString = "{\n" +
                 "    \"doc\" : {\n" +
-                "        \"" + updateType + "\" : [\"" + updateIds + "\"]\n" +
+                "        \"" + updateType + "\" : [" + updateIds + "]\n" +
                 "    }\n" +
                 "}";
 

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/AddPatientTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/AddPatientTask.java
@@ -77,6 +77,11 @@ public class AddPatientTask extends AsyncTask<String, Void, Boolean> {
 
             Patient patient = searchResult.getSourceAsObject(Patient.class, true);
 
+            // If the CP already has this patient, do not add again
+            if (careProvider.getPatients().contains(patient)) {
+                return false;
+            }
+
             careProvider.addPatient(patient);
 
             String patientId = patient.getId();

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetPatientListTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetPatientListTask.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
+import io.searchbox.params.SearchType;
 
 /**
  * GetPatientListTask is responsible for taking in a careProviderId and returning a List of Patients
@@ -53,7 +54,6 @@ public class GetPatientListTask extends AsyncTask<String, Void, List<Patient>> {
                     .build();
             // populate our Problem model with database values corresponding to _id
             SearchResult res = IrisProjectApplication.getDB().execute(get);
-
 
             Log.i(TAG, res.getJsonString());
             System.out.println(Arrays.toString(res.getSourceAsStringList().toArray()));

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetUserDataTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetUserDataTask.java
@@ -81,10 +81,6 @@ public class GetUserDataTask extends AsyncTask<User, Void, Void> {
      * @param careProvider the bound-to Care Provider
      */
     private void getAndBindPatients(CareProvider careProvider) {
-
-        System.out.println(Arrays.toString(careProvider.getPatientIds().toArray()));
-        System.out.println(careProvider.getPatientIds().size());
-
         List<Patient> patients = new ArrayList<>();
 
         for (String patientId : careProvider.getPatientIds()) {
@@ -96,7 +92,6 @@ public class GetUserDataTask extends AsyncTask<User, Void, Void> {
             }
 
             Patient patient = res.getSourceAsObject(Patient.class, true);
-            System.out.println("patient is " + patient);
             patients.add(patient);
         }
         careProvider.setPatients(patients);

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetUserDataTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/GetUserDataTask.java
@@ -19,6 +19,8 @@ import com.team7.cmput301.android.theirisproject.model.RecordPhoto;
 import com.team7.cmput301.android.theirisproject.model.User;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import io.searchbox.core.Search;
@@ -80,19 +82,28 @@ public class GetUserDataTask extends AsyncTask<User, Void, Void> {
      */
     private void getAndBindPatients(CareProvider careProvider) {
 
-        String query = generateQuery(MATCH, "careProviderIds", careProvider.getId());
-        SearchResult res = search(query, "user");
+        System.out.println(Arrays.toString(careProvider.getPatientIds().toArray()));
+        System.out.println(careProvider.getPatientIds().size());
 
-        if (res != null) {
+        List<Patient> patients = new ArrayList<>();
 
-            List<Patient> patients = res.getSourceAsObjectList(Patient.class, true);
-            careProvider.setPatients(patients);
+        for (String patientId : careProvider.getPatientIds()) {
+            String query = generateQuery(TERM, "_id", patientId);
+            SearchResult res = search(query, "user");
 
-            for (Patient patient: patients) {
-                getAndBindProblems(patient);
+            if (res == null) {
+                printError(CareProvider.class, careProvider.getId());
             }
 
-        } else printError(CareProvider.class, careProvider.getId());
+            Patient patient = res.getSourceAsObject(Patient.class, true);
+            System.out.println("patient is " + patient);
+            patients.add(patient);
+        }
+        careProvider.setPatients(patients);
+
+        for (Patient patient: patients) {
+            getAndBindProblems(patient);
+        }
 
     }
 


### PR DESCRIPTION
Patient list now uses Patients from current user instead of querying from Elasticsearch. When a new Patient is added, that Patient is added to the current user's list so we don't have to re-run a GetPatientListTask (this was causing lots of problems with speed and we were forced to make the UI thread sleep which was a super bad idea)

Also fixed a substantial bug where the patientIds and careProviderIds were stored in the DB as one string, notice where the quotations are here 
![image](https://user-images.githubusercontent.com/11599574/48975721-9b57fa80-f034-11e8-9297-6f59abb43693.png)

Also added sanity checks to AddPatientTask.
Now it checks if: 
- there is a user that exists with that username
- if the user found is actually a patient
- if the patient is already in the care provider's list.