### PR TITLE
Add groundwork for bulk updating after connection restored 

### DIFF
--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisProjectApplication.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisProjectApplication.java
@@ -131,14 +131,14 @@ public class IrisProjectApplication extends Application {
      */
     public static void putInUpdateQueue(Object model) {
 
-        if (model.getClass() == Problem.class) {
+        if (model instanceof Problem) {
             problemUpdateQueue.add((Problem) model);
         }
-        else if (model.getClass() == Record.class) {
+        else if (model instanceof Record) {
             recordUpdateQueue.add((Record) model);
         }
         else {
-            System.err.println("Trying to put unhandled type into update Queue!");
+            System.err.println("Trying to put unhandled type into update queue!");
         }
 
         // queues should still be updated even if they aren't re-passed as arguments

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/task/BulkUpdateTask.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/task/BulkUpdateTask.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Team 7, CMPUT301, University of Alberta - All Rights Reserved. You may use, distribute, or modify this code under terms and conditions of the Code of Students Behavior at University of Alberta
+ */
+
+package com.team7.cmput301.android.theirisproject.task;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import com.team7.cmput301.android.theirisproject.IrisProjectApplication;
+import com.team7.cmput301.android.theirisproject.helper.Timer;
+import com.team7.cmput301.android.theirisproject.model.Problem;
+import com.team7.cmput301.android.theirisproject.model.Record;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.searchbox.core.Bulk;
+import io.searchbox.core.Index;
+
+/**
+ * Periodically checks internet connection, and bulk updates models that have changed
+ * when internet connection detected.
+ * https://stackoverflow.com/a/44982271
+ *
+ * @author anticobalt
+ * @see IrisProjectApplication
+ */
+public class BulkUpdateTask extends AsyncTask<List, Void, Boolean> {
+
+    private final WeakReference<Context> reference;
+    private Callback<Boolean> callback;
+    private int sleepDuration = 120000; // 2 minutes
+
+    public BulkUpdateTask(Context context, Callback<Boolean> callback) {
+        this.reference = new WeakReference<>(context);
+        this.callback = callback;
+    }
+
+    /**
+     * https://stackoverflow.com/q/48804373
+     *
+     * @param lists The queues of models that need to be uploaded
+     * @return Success or failure
+     */
+    @Override
+    protected Boolean doInBackground(List... lists) {
+
+        while (!IrisProjectApplication.isConnectedToInternet(reference.get())){
+            Timer.sleep(sleepDuration);
+        }
+
+        List<Index> indexList = new ArrayList<>();
+        Bulk update;
+
+        // Update problems
+        for (Object model : lists[0]) {
+            Problem problem = (Problem) model;
+            Index index = new Index.Builder(problem)
+                    .id(problem.getId())
+                    .index(IrisProjectApplication.INDEX)
+                    .type("problem")
+                    .build();
+            indexList.add(index);
+        }
+        update = new Bulk.Builder().addAction(indexList).build();
+        try {
+            IrisProjectApplication.getDB().execute(update);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        // Update records
+        // TODO: have Problems and Records extend/implement something so that this operation can be generalized
+        // ( model.getID() is problematic part, every other variable part can be parameterized )
+        indexList.clear();
+        for (Object model : lists[1]) {
+            Record record = (Record) model;
+            Index index = new Index.Builder(record)
+                    .id(record.getId())
+                    .index(IrisProjectApplication.INDEX)
+                    .type("record")
+                    .build();
+            indexList.add(index);
+        }
+        update = new Bulk.Builder().addAction(indexList).build();
+        try {
+            IrisProjectApplication.getDB().execute(update);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+
+    }
+
+    @Override
+    protected void onPostExecute(Boolean aBoolean) {
+        super.onPostExecute(aBoolean);
+        callback.onComplete(aBoolean);
+    }
+}
+


### PR DESCRIPTION
Doesn't actually do anything yet, just need some critique/evaluation before stuff is actually integrated into existing system.

- IrisControllers will check internet status, and if offline, will pass updated models to putInUpdateQueue(); this function will start BulkUpdaterTask (if it isn't already running), which periodically checks internet status in attempt to upload updates in update queue
- The first Activity (probably LoginActivity or the User's unique landing page) will call initBulkUpdater() and pass the application context, which is required by BulkUpdaterTask for internet status check