### PR TITLE
 Add update-queue disk backup/restore; integrate into EditRecordController; fixes

### DIFF
--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisProjectApplication.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/IrisProjectApplication.java
@@ -169,8 +169,11 @@ public class IrisProjectApplication extends Application {
      * @param callback The callback that defines that occurs after update finished.
      */
     public static void flushUpdateQueueBackups(Callback<Boolean> callback) {
+
         BulkUpdateTask updater = new BulkUpdateTask(appContext, callback);
         LocalStorageHandler fileHandler = new LocalStorageHandler();
+
+        // Bulk update with backups
         updater.execute(
                 fileHandler.loadListFromBackupFile(
                         appContext,
@@ -183,6 +186,11 @@ public class IrisProjectApplication extends Application {
                         new Record()
                 )
         );
+
+        // clear the backups
+        fileHandler.saveListToBackupFile(appContext, new ArrayList<>(), problemUpdateBackupName);
+        fileHandler.saveListToBackupFile(appContext, new ArrayList<>(), recordUpdateBackupName);
+
     }
 
     public static void addProblemToCache(Problem problem) {

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/LocalStorageHandler.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/LocalStorageHandler.java
@@ -96,7 +96,6 @@ public class LocalStorageHandler {
             objects = gson.fromJson(reader, listType);
 
         } catch (FileNotFoundException e) {
-            // TODO Auto-generated catch block
             objects = new ArrayList<>();
             e.printStackTrace();
         }

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/LocalStorageHandler.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/LocalStorageHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Team 7, CMPUT301, University of Alberta - All Rights Reserved. You may use, distribute, or modify this code under terms and conditions of the Code of Students Behavior at University of Alberta
+ */
+
+package com.team7.cmput301.android.theirisproject;
+
+import android.content.Context;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.team7.cmput301.android.theirisproject.model.Problem;
+import com.team7.cmput301.android.theirisproject.model.Record;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Write to and read from file using Gson.
+ * Mostly a copy of the CMPUT301 lab tutorial material by Shaiful Chowdhury.
+ *
+ * @author anticobalt
+ */
+public class LocalStorageHandler {
+
+    /**
+     * Takes a list unknown type items, and saves it in JSON format to file.
+     *
+     * @param context application context; required for opening file output byte stream
+     * @param list Objects to be serialized
+     * @param filename Name of file that will hold serialized objects on device
+     */
+    public void saveListToBackupFile(Context context, List<?> list, String filename) {
+
+        try {
+
+            FileOutputStream fos = context.openFileOutput(filename, 0);
+            OutputStreamWriter osw = new OutputStreamWriter(fos);
+            BufferedWriter writer = new BufferedWriter(osw);
+
+            Gson gson = new Gson();
+            gson.toJson(list, writer);
+            writer.flush();
+            fos.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    /**
+     * Returns file's serialized objects as a List.
+     * An example model is provided to determine how to serialize object.
+     * The alternative is to have caller functions pass in a raw string that is to be compared,
+     * which seems less extendable than containing the string-comparison ugliness to this function.
+     *
+     * @param context application context; required for opening file input byte stream
+     * @param filename Name of file to read from
+     * @param model An instance of the model type that is to be serialized
+     * @return The list of deserialized objects
+     */
+    public List loadListFromBackupFile(Context context, String filename, Object model) {
+
+        List objects;
+
+        try {
+
+            FileInputStream fis = context.openFileInput(filename);
+            InputStreamReader isr = new InputStreamReader(fis);
+            BufferedReader reader = new BufferedReader(isr);
+
+            Gson gson = new Gson();
+
+            // a hack to generate the right type of objects
+            Type listType;
+            switch(model.getClass().getSimpleName()) {
+                case "Problem":
+                    listType = new TypeToken<ArrayList<Problem>>(){}.getType();
+                    break;
+                case "Record":
+                    listType = new TypeToken<ArrayList<Record>>(){}.getType();
+                    break;
+                default:
+                    return new ArrayList();
+            }
+
+            objects = gson.fromJson(reader, listType);
+
+        } catch (FileNotFoundException e) {
+            // TODO Auto-generated catch block
+            objects = new ArrayList<>();
+            e.printStackTrace();
+        }
+
+        return objects;
+
+    }
+
+
+}

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/LoginActivity.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/activity/LoginActivity.java
@@ -36,7 +36,9 @@ public class LoginActivity extends IrisActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
 
+        IrisProjectApplication.setApplicationContext(getApplicationContext());
         controller = createController(getIntent());
+        IrisProjectApplication.initBulkUpdater();
 
         // initialize android views from xml
         loginButton = findViewById(R.id.login_button);
@@ -81,11 +83,12 @@ public class LoginActivity extends IrisActivity {
     }
 
     /**
-     * Get all the logged in User's associated data, then start a specified activity for them
+     * Push the update queue backups to online, get all the logged in User's associated data,
+     * then start a specified activity for them.
      */
     private void buildUserSession() {
 
-        Callback callback = new Callback() {
+        Callback callbackToStart = new Callback() {
             @Override
             public void onComplete(Object res) {
                 Class activity = controller.getStartingActivity();
@@ -93,7 +96,14 @@ public class LoginActivity extends IrisActivity {
             }
         };
 
-        controller.fetchAllUserData(callback);
+        Callback<Boolean> callbackToFetch = new Callback<Boolean>() {
+            @Override
+            public void onComplete(Boolean res) {
+                controller.fetchAllUserData(callbackToStart);
+            }
+        };
+
+        IrisProjectApplication.flushUpdateQueueBackups(callbackToFetch);
 
     }
 

--- a/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/EditRecordController.java
+++ b/app/src/main/java/com/team7/cmput301/android/theirisproject/controller/EditRecordController.java
@@ -50,7 +50,7 @@ public class EditRecordController extends IrisController<Record> {
      * @param context Required for internet check
      * @param title Record's new title
      * @param desc Record's new description
-     * @return
+     * @return Whether update to online was possible or not
      */
     public boolean submitRecord(Context context, String title, String desc){
 
@@ -62,6 +62,8 @@ public class EditRecordController extends IrisController<Record> {
         if (IrisProjectApplication.isConnectedToInternet(context)) {
             new EditRecordTask().execute(record);
             pushedOnline = true;
+        } else {
+            IrisProjectApplication.putInUpdateQueue(record);
         }
 
         return pushedOnline;


### PR DESCRIPTION
Changes/additions:
- When EditRecordController sees that internet is down, it pushes updated Record to update queue
- Record only put into queue if not already in it
- When queue is updated, it is backed up to disk
- When internet is restored and queue's data is written to elasticsearch, the backups are cleared
- When a User logs in, the backups are read and their contents pushed to elasticsearch *before* User data is fetched; backups then emptied
- First Activity will set the application context in IrisProjectApplication (so it doesn't have to be constantly passed into methods that need it, and there are a bunch of these kinds of methods)

Any critique appreciated, because the code at this point is looking kind of hacky, and I couldn't find a way to get around it.